### PR TITLE
[FIX] Add new DBsearchDeconvMass util to list of executables to be built (and documented)

### DIFF
--- a/src/utils/executables.cmake
+++ b/src/utils/executables.cmake
@@ -8,6 +8,7 @@ AssayGeneratorMetabo
 ClusterMassTraces
 ClusterMassTracesByPrecursor
 CVInspector
+DBsearchDeconvMass
 DatabaseFilter
 DecoyDatabase
 DeMeanderize


### PR DESCRIPTION
Hi!
I found this when checking the error. Might not solve everything, but this is needed to tell the build system to consider your ".cpp" at all.
